### PR TITLE
tagでのページ遷移

### DIFF
--- a/components/ArticleMeta.tsx
+++ b/components/ArticleMeta.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import React, { FC } from 'react'
 import { ArticleMetaProps } from '../types/type'
 import { getCover, getDate, getMultiSelect, getText } from '../utils/propaty'
@@ -36,7 +37,11 @@ const ArticleMeta: FC<ArticleMetaProps> = ({ page }) => {
                 <div className="col-span-2">
                     {/* change later */}
                     {getMultiSelect(page.properties.tags.multi_select).map((tag:string , index:number)=> (
-                    <span key={index}>{`#${tag}`}</span>
+                    <Link key={index} href={`/tags/${tag}`}>
+                        <a className="text-gray-700 no-underline border-b border-solid border-gray-700 opacity-70 mr-3">
+                            <span>{`#${tag}`}</span>
+                        </a>
+                    </Link>
                 ))}
                 </div>
                 </div>

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -1,0 +1,68 @@
+import type { GetStaticPaths, GetStaticProps, NextPage } from 'next'
+import Card from '../../components/Cards'
+import Layout from '../../components/Layout'
+import Section from '../../components/Section'
+import { indexProps, tagProps } from '../../types/type'
+import { responsePage } from '../../utils/notion'
+import { params } from '../../types/type'
+import { getMultiSelect, getText } from '../../utils/propaty'
+
+export const getStaticPaths:GetStaticPaths = async () => {
+    // responsePageに存在しうるpathの一覧を取得する
+    const { results }: {results: Record<string, any>[]} = await responsePage({});
+
+    // Setインスタンスで重複を避けてくれる
+    const pathSet: Set<string> = new Set()
+    for ( const page of results) {
+        for ( const tag of getMultiSelect(page.properties.tags.multi_select)) {
+            // tagの重複を防ぐ
+            pathSet.add(tag)
+        }
+    }
+
+    // pathの集合をArray.fromで配列に変換して,mapで回している
+    const paths = Array.from(pathSet).map((tag) => {
+        return {
+            params: {
+                tag: tag,
+            }
+        }
+    })
+    return {
+        paths: paths,
+        fallback: "blocking",
+    }
+}
+
+// SSG = ビルドの段階でHTMLが生成される状態になっている = 事前生成 = ビルドが何度も行なわれるのがデメリット= ビルドを行うと他のページも全てビルドし直すため処理が大変
+export const getStaticProps:GetStaticProps = async (context) => {
+    const { tag } = context.params as params ;
+    const { results } = await responsePage({ tag }); 
+    return {
+        props: {
+        pages: results ? results : [], 
+        tag  : tag,
+        },
+        revalidate: 5,
+    };
+};
+
+const tag: NextPage<tagProps> = ({ pages, tag }) => {
+    console.log(pages);
+    return (
+        <Layout>
+        <Section />
+        <div className="pt-12">
+            <h1 className="text-5xl mb-8">{`#${tag}`}</h1>
+            <div className="grid md:gap-6 mt-10 md:grid-cols-2 w-full my-12">
+            {/* Card */}
+            {pages.map((page,index) => (
+                <Card key={index} page={page} />
+            ))}
+            </div>
+        </div>
+        </Layout>
+    )
+}
+
+export default tag

--- a/types/type.ts
+++ b/types/type.ts
@@ -28,7 +28,8 @@ export type ArticleProps = {
 export type ArticleMetaProps = CardProps
 
 export type params = ParsedUrlQuery & {
-    slug: "string"
+    slug : "string",
+    tag  : "string"
 }
 
 
@@ -71,6 +72,7 @@ export type indexProps = {
     pages: pageType[];
 }
 
+export type tagProps = indexProps & { tag: string }
 // export type BlockType = {
 //     type: string;
 //     heading_1: { rich_text: richTextType[] };

--- a/utils/notion.ts
+++ b/utils/notion.ts
@@ -4,7 +4,7 @@ const notion = new Client({ auth: process.env.NOTION_KEY as string});
 
 const DATABASE_ID = process.env.NOTION_DATABASE_ID as string;
 
-export const responsePage = async ({ slug } : {slug?: string }) => {
+export const responsePage = async ({ slug, tag } : {slug?: string, tag?: string}) => {
 
     const and:any = [
         {
@@ -31,6 +31,16 @@ export const responsePage = async ({ slug } : {slug?: string }) => {
                 property: "slug",
                 rich_text: {
                 equals: slug,
+                },
+            },
+        );
+    };
+    if( tag ) {
+        and.push(
+            {
+                property: "tags",
+                multi_select: {
+                    contains: tag
                 },
             },
         );


### PR DESCRIPTION
// Setインスタンスで重複を避けてくれる
    const pathSet: Set<string> = new Set()
    for ( const page of results) {
        for ( const tag of getMultiSelect(page.properties.tags.multi_select)) {
            // tagの重複を防ぐ
            pathSet.add(tag)
        }
    }
二重のfor of 文　